### PR TITLE
Editable installs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -515,6 +515,7 @@ pep-0657.rst  @pablogsal @isidentical @ammaraskar
 pep-0658.rst  @brettcannon
 pep-0659.rst  @markshannon
 pep-0660.rst  @pfmoore
+pep-0661.rst  @taleinat
 # ...
 # pep-0666.txt
 # ...

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -516,6 +516,7 @@ pep-0658.rst  @brettcannon
 pep-0659.rst  @markshannon
 pep-0660.rst  @pfmoore
 pep-0661.rst  @taleinat
+pep-0662.rst  @brettcannon
 # ...
 # pep-0666.txt
 # ...

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -1,0 +1,42 @@
+name: Deploy to GitHub Pages
+
+on: [push]
+
+jobs:
+  deploy-to-pages:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v2
+
+      - name: 🐍 Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: 🧳 Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+
+      - name: 👷‍ Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: 🔧 Build PEPs
+        run: make pages -j$(nproc)
+
+      - name: 🚀 Deploy to GitHub pages
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: gh-pages # The branch to deploy to.
+          folder: build # Synchronise with build.py -> build_directory
+          single-commit: true # Delete existing files

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -1,6 +1,8 @@
 name: Deploy to GitHub Pages
 
-on: [push]
+on:
+  push:
+    branches: [master]
 
 jobs:
   deploy-to-pages:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__
 .vscode
 *.swp
 /build
+/package
+/venv

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,12 @@ pages: rss
 sphinx:
 	$(SPHINX_BUILD)
 
-fail_on_warning:
+# for building Sphinx without a web-server
+sphinx-local:
+	$(SPHINX_BUILD) --build-files
+
+fail-warning:
 	$(SPHINX_BUILD) --fail-on-warning
 
-check_links:
+check-links:
 	$(SPHINX_BUILD) --check-links

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,5 @@
-# Rules to only make the required HTML versions, not all of them,
-# without the user having to keep track of which.
-#
-# Not really important, but convenient.
+# Builds PEP files to HTML using docutils or sphinx
+# Also contains testing targets
 
 PEP2HTML=pep2html.py
 
@@ -34,7 +32,6 @@ install:
 
 clean:
 	-rm pep-0000.rst
-	-rm pep-0000.txt
 	-rm *.html
 	-rm -rf build
 
@@ -43,7 +40,7 @@ update:
 
 venv:
 	$(PYTHON) -m venv $(VENV_DIR)
-	./$(VENV_DIR)/bin/python -m pip install -U docutils
+	./$(VENV_DIR)/bin/python -m pip install -r requirements.txt
 
 package: all rss
 	mkdir -p build/peps
@@ -57,3 +54,20 @@ package: all rss
 lint:
 	pre-commit --version > /dev/null || python3 -m pip install pre-commit
 	pre-commit run --all-files
+
+# New Sphinx targets:
+
+SPHINX_JOBS=8
+SPHINX_BUILD=$(PYTHON) build.py -j $(SPHINX_JOBS)
+
+pages: rss
+	$(SPHINX_BUILD) --index-file
+
+sphinx:
+	$(SPHINX_BUILD)
+
+fail_on_warning:
+	$(SPHINX_BUILD) --fail-on-warning
+
+check_links:
+	$(SPHINX_BUILD) --check-links

--- a/build.py
+++ b/build.py
@@ -1,0 +1,54 @@
+"""Build script for Sphinx documentation"""
+
+import argparse
+from pathlib import Path
+
+from sphinx.application import Sphinx
+
+
+def create_parser():
+    parser = argparse.ArgumentParser(description="Build PEP documents")
+    # alternative builders:
+    parser.add_argument("-l", "--check-links", action="store_true")
+
+    # flags / options
+    parser.add_argument("-f", "--fail-on-warning", action="store_true")
+    parser.add_argument("-n", "--nitpicky", action="store_true")
+    parser.add_argument("-j", "--jobs", type=int)
+
+    # extra build steps
+    parser.add_argument("-i", "--index-file", action="store_true")  # for PEP 0
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = create_parser()
+
+    root_directory = Path(".").absolute()
+    source_directory = root_directory
+    build_directory = root_directory / "build"  # synchronise with deploy-gh-pages.yaml -> deploy step
+    doctree_directory = build_directory / ".doctrees"
+
+    # builder configuration
+    sphinx_builder = "dirhtml"
+    if args.check_links:
+        sphinx_builder = "linkcheck"
+
+    # other configuration
+    config_overrides = {}
+    if args.nitpicky:
+        config_overrides["nitpicky"] = True
+
+    app = Sphinx(
+        source_directory,
+        confdir=source_directory,
+        outdir=build_directory,
+        doctreedir=doctree_directory,
+        buildername=sphinx_builder,
+        confoverrides=config_overrides,
+        warningiserror=args.fail_on_warning,
+        parallel=args.jobs,
+    )
+    app.builder.copysource = False  # Prevent unneeded source copying - we link direct to GitHub
+    app.build()

--- a/build.py
+++ b/build.py
@@ -10,9 +10,11 @@ def create_parser():
     parser = argparse.ArgumentParser(description="Build PEP documents")
     # alternative builders:
     parser.add_argument("-l", "--check-links", action="store_true")
+    parser.add_argument("-f", "--build-files", action="store_true")
+    parser.add_argument("-d", "--build-dirs", action="store_true")
 
     # flags / options
-    parser.add_argument("-f", "--fail-on-warning", action="store_true")
+    parser.add_argument("-w", "--fail-on-warning", action="store_true")
     parser.add_argument("-n", "--nitpicky", action="store_true")
     parser.add_argument("-j", "--jobs", type=int, default=1)
 
@@ -31,9 +33,15 @@ if __name__ == "__main__":
     doctree_directory = build_directory / ".doctrees"
 
     # builder configuration
-    sphinx_builder = "dirhtml"
-    if args.check_links:
+    if args.build_files:
+        sphinx_builder = "html"
+    elif args.build_dirs:
+        sphinx_builder = "dirhtml"
+    elif args.check_links:
         sphinx_builder = "linkcheck"
+    else:
+        # default builder
+        sphinx_builder = "dirhtml"
 
     # other configuration
     config_overrides = {}

--- a/build.py
+++ b/build.py
@@ -14,7 +14,7 @@ def create_parser():
     # flags / options
     parser.add_argument("-f", "--fail-on-warning", action="store_true")
     parser.add_argument("-n", "--nitpicky", action="store_true")
-    parser.add_argument("-j", "--jobs", type=int)
+    parser.add_argument("-j", "--jobs", type=int, default=1)
 
     # extra build steps
     parser.add_argument("-i", "--index-file", action="store_true")  # for PEP 0

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,37 @@
+"""Configuration for building PEPs using Sphinx."""
+
+# -- Project information -----------------------------------------------------
+
+project = "PEPs"
+master_doc = "contents"
+
+# -- General configuration ---------------------------------------------------
+
+# The file extensions of source files. Sphinx uses these suffixes as sources.
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".txt": "restructuredtext",
+}
+
+# List of patterns (relative to source dir) to ignore when looking for source files.
+exclude_patterns = [
+    # Windows:
+    "Thumbs.db",
+    ".DS_Store",
+    # Python:
+    "venv",
+    "requirements.txt",
+    # Sphinx:
+    "build",
+    "output.txt",  # Link-check output
+    # PEPs:
+    "README.rst",
+    "CONTRIBUTING.rst",
+]
+
+# -- Options for HTML output -------------------------------------------------
+
+# HTML output settings
+html_show_copyright = False  # Turn off miscellany
+html_show_sphinx = False
+html_title = "peps.python.org"  # Set <title/>

--- a/conf.py
+++ b/conf.py
@@ -1,5 +1,10 @@
 """Configuration for building PEPs using Sphinx."""
 
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path("pep_sphinx_extensions").absolute()))
+
 # -- Project information -----------------------------------------------------
 
 project = "PEPs"
@@ -7,10 +12,13 @@ master_doc = "contents"
 
 # -- General configuration ---------------------------------------------------
 
+# Add any Sphinx extension module names here, as strings.
+extensions = ["pep_sphinx_extensions", "sphinx.ext.githubpages"]
+
 # The file extensions of source files. Sphinx uses these suffixes as sources.
 source_suffix = {
-    ".rst": "restructuredtext",
-    ".txt": "restructuredtext",
+    ".rst": "pep",
+    ".txt": "pep",
 }
 
 # List of patterns (relative to source dir) to ignore when looking for source files.
@@ -32,6 +40,7 @@ exclude_patterns = [
 # -- Options for HTML output -------------------------------------------------
 
 # HTML output settings
+html_math_renderer = "maths_to_html"  # Maths rendering
 html_show_copyright = False  # Turn off miscellany
 html_show_sphinx = False
 html_title = "peps.python.org"  # Set <title/>

--- a/contents.rst
+++ b/contents.rst
@@ -1,0 +1,16 @@
+
+Python Enhancement Proposals (PEPs)
+***********************************
+
+
+This is an internal Sphinx page, please go to the :doc:`PEP Index<pep-0000>`.
+
+
+.. toctree::
+   :maxdepth: 3
+   :titlesonly:
+   :hidden:
+   :glob:
+   :caption: PEP Table of Contents (needed for Sphinx):
+
+   pep-*

--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -227,11 +227,6 @@ to perform some manual editing steps.
   (e.g. ``blurb release 3.4.7rc1``).  This merges all the recent news
   blurbs into a single file marked with this release's version number.
 
-- Check the docs for markup errors.
-
-  cd to the Doc directory and run ``make suspicious``.  If any markup
-  errors are found, fix them.
-
 - Regenerate Lib/pydoc-topics.py.
 
   While still in the Doc directory, run ``make pydoc-topics``.  Then copy

--- a/pep-0101.txt
+++ b/pep-0101.txt
@@ -306,8 +306,7 @@ to perform some manual editing steps.
 
 - For a **final** major release, update the ``VERSIONS`` list of
   `docsbuild scripts`_: the release branch must be changed from
-  ``pre-release`` to ``stable``, tell the DE to update the ``/3/``
-  symlink.
+  ``pre-release`` to ``stable``.
 
 - For **begin security-only mode** and **end-of-life** releases, review the
   two files and update the versions accordingly in all active branches.

--- a/pep-0515.txt
+++ b/pep-0515.txt
@@ -175,13 +175,13 @@ References
 
 .. [1] http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3499.html
 
-.. [2] http://dlang.org/spec/lex.html#integerliteral
+.. [2] https://dlang.org/spec/lex.html#integerliteral
 
-.. [3] http://perldoc.perl.org/perldata.html#Scalar-value-constructors
+.. [3] https://perldoc.perl.org/perldata#Scalar-value-constructors
 
-.. [4] http://doc.rust-lang.org/reference.html#number-literals
+.. [4] https://web.archive.org/web/20160304121349/http://doc.rust-lang.org/reference.html#integer-literals
 
-.. [5] https://developer.apple.com/library/ios/documentation/Swift/Conceptual/Swift_Programming_Language/LexicalStructure.html
+.. [5] https://docs.swift.org/swift-book/ReferenceManual/LexicalStructure.html
 
 .. [6] https://github.com/dotnet/roslyn/issues/216
 
@@ -189,9 +189,9 @@ References
 
 .. [8] http://archive.adaic.com/standards/83lrm/html/lrm-02-04.html#2.4
 
-.. [9] http://docs.julialang.org/en/release-0.4/manual/integers-and-floating-point-numbers/
+.. [9] https://web.archive.org/web/20160223175334/http://docs.julialang.org/en/release-0.4/manual/integers-and-floating-point-numbers/
 
-.. [10] http://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html#label-Numbers
+.. [10] https://ruby-doc.org/core-2.3.0/doc/syntax/literals_rdoc.html#label-Numbers
 
 .. [11] https://mail.python.org/pipermail/python-dev/2016-February/143283.html
 

--- a/pep-0658.rst
+++ b/pep-0658.rst
@@ -1,5 +1,5 @@
 PEP: 658
-Title: Static Distribution Metadata in the Simple Repository API
+Title: Serve Distribution Metadata in the Simple Repository API
 Author: Tzu-ping Chung <uranusjr@gmail.com>
 Sponsor: Brett Cannon <brett@python.org>
 PEP-Delegate: Donald Stufft <donald@stufft.io>
@@ -48,19 +48,16 @@ inspection.
 The metadata file defined by the Core Metadata Specification
 [core-metadata]_ will be served directly by repositories since it
 contains the necessary information for common use cases. The metadata
-served must be completely static, i.e. identical to the ``METADATA``
-file in the ``.dist-info`` directory [dist-info]_ if the distribution
-is installed. The repository can provide this for any distributions,
-but it is expected they will only provide them for wheels [wheel]_
-at the current time, since an sdist [sdist]_ does not yet have a way
-to promise the metadata will stay the same after it is built.
+must only be served for standards-compliant distributions such as
+wheels [wheel]_ and sdists [sdist]_, and must be identical to the
+distribution's canonical metadata file, such as a wheel's ``METADATA``
+file in the ``.dist-info`` directory [dist-info]_.
 
-Since not all distributions have static metadata, an HTML attribute
-on the distribution file's anchor link is needed to indicate whether a
-client is able to choose the separately served metadata file instead.
-The attribute is also used to provide the metadata file's hash, so
-clients can verify the file after download. If the attribute is
-missing from an anchor link, static metadata is not available for the
+An HTML attribute on the distribution file's anchor link is needed to
+indicate whether a client is able to choose the separately served
+metadata file. The attribute is also used to provide the metadata
+content's hash for client-side verification. The attribute's absence
+indicates that a separate metadata entry is not available for the
 distribution, either because of the distribution's content, or lack of
 repository support.
 

--- a/pep-0661.rst
+++ b/pep-0661.rst
@@ -1,0 +1,323 @@
+PEP: 661
+Title: Sentinel Values
+Author: Tal Einat <tal@python.org>
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 06-Jun-2021
+Post-History: 06-Jun-2021
+
+
+TL;DR: See the `Specification`_ and `Reference Implementation`_.
+
+
+Abstract
+========
+
+Unique placeholder values, widely known as "sentinel values", are useful in
+Python programs for several things, such as default values for function
+arguments where ``None`` is a valid input value.  These cases are common
+enough for several idioms for implementing such "sentinels" to have arisen
+over the years, but uncommon enough that there hasn't been a clear need for
+standardization.  However, the common implementations, including some in the
+stdlib, suffer from several significant drawbacks.
+
+This PEP suggests adding a utility for defining sentinel values, to be used
+in the stdlib and made publicly available as part of the stdlib.
+
+Note: Changing all existing sentinels in the stdlib to be implemented this
+way is not deemed necessary, and whether to do so is left to the discretion
+of each maintainer.
+
+
+Motivation
+==========
+
+In May 2021, a question was brought up on the python-dev mailing list
+[#python-dev-thread]_ about how to better implement a sentinel value for
+``traceback.print_exception``.  The existing implementation used the
+following common idiom:
+
+::
+
+    _sentinel = object()
+
+However, this object has an overly verbose repr, causing the function's
+signature to be overly long and hard to read, as seen e.g. when calling
+``help()``:
+
+::
+
+    >>> help(traceback.print_exception)
+    Help on function print_exception in module traceback:
+
+    print_exception(exc, /, value=<object object at
+    0x000002825DF09650>, tb=<object object at 0x000002825DF09650>,
+    limit=None, file=None, chain=True)
+
+Additionally, two other drawbacks of many existing sentinels were brought up
+in the discussion:
+
+1. Not having a distinct type, hence it being impossible to define strict
+   type signatures functions with sentinels as default values
+2. Incorrect behavior after being copied or unpickled, due to a separate
+   instance being created and thus comparisons using ``is`` failing
+
+In the ensuing discussion, Victor Stinner supplied a list of currently used
+sentinel values in the Python standard library [#list-of-sentinels-in-stdlib]_.
+This showed that the need for sentinels is fairly common, that there are
+various implementation methods used even within the stdlib, and that many of
+these suffer from at least one of the aforementioned drawbacks.
+
+The discussion did not lead to any clear consensus on whether a standard
+implementation method is needed or desirable, whether the drawbacks mentioned
+are significant, nor which kind of implementation would be good.
+
+A poll was created on discuss.python.org [#poll]_to get a clearer sense of
+the community's opinions. The poll's results were not conclusive, with 40%
+voting for "The status-quo is fine / there’s no need for consistency in
+this", but most voters voting for one or more standardized solutions.
+Specifically, 37% of the voters chose "Consistent use of a new, dedicated
+sentinel factory / class / meta-class, also made publicly available in the
+stdlib".
+
+With such mixed opinions, this PEP was created to facilitate making a decision
+on the subject.
+
+
+Rationale
+=========
+
+The criteria guiding the chosen implementation were:
+
+1. The sentinel objects should behave as expected by a sentinel object: When
+   compared using the ``is`` operator, it should always be considered identical
+   to itself but never to any other object.
+2. It should be simple to define as many distinct sentinel values as needed.
+3. The sentinel objects should have a clear and short repr.
+4. The sentinel objects should each have a *distinct* type, usable in type
+   annotations to define *strict* type signatures.
+5. The sentinel objects should behave correctly after copying and/or
+   unpickling.
+6. Creating a sentinel object should be a simple, straightforward one-liner.
+7. Works using CPython and PyPy3.  Will hopefully also work with other
+   implementations.
+
+After researching existing idioms and implementations, and going through many
+different possible implementations, an implementation was written which meets
+all of these criteria (see `Reference Implementation`_).
+
+
+Specification
+=============
+
+A new ``sentinel`` function will be added to a new ``sentinels`` module.
+It will accept a single required argument, the name of the sentinel object,
+and a single optional argument, the repr of the object.
+
+::
+
+    >>> NotGiven = sentinel('NotGiven')
+    >>> NotGiven
+    <NotGiven>
+    >>> MISSING = sentinel('MISSING', repr='mymodule.MISSING')
+    >>> MISSING
+    mymodule.MISSING
+
+
+A third optional argument, the name of the module where the sentinel is
+defined, exists to be used to support cases where the name of the module
+cannot be found by inspecting the stack frame.  This is identical to the
+pattern used by ``collections.namedtuple``.  (The name of the module is
+used to choose a unique name for the class generated for the new sentinel,
+which is set as an attribute of the ``sentinels`` module.)
+
+
+Reference Implementation
+========================
+
+The reference implementation is found in a dedicated GitHub repo
+[#reference-github-repo]_.  A simplified version follows::
+
+    def sentinel(name, repr=None):
+        """Create a unique sentinel object."""
+        repr = repr or f'<{name}>'
+
+        module = _get_parent_frame().f_globals.get('__name__', '__main__')
+        class_name = _get_class_name(name, module)
+        class_namespace = {
+            '__repr__': lambda self: repr,
+        }
+        cls = type(class_name, (), class_namespace)
+        cls.__module__ = __name__
+        globals()[class_name] = cls
+
+        sentinel = cls()
+        cls.__new__ lambda cls: sentinel
+
+        return sentinel
+
+    def _get_class_name(sentinel_qualname, module_name):
+        return '__'.join(['_sentinel_type',
+                          module_name.replace('.', '_'),
+                          sentinel_qualname.replace('.', '_')])
+
+
+Rejected Ideas
+==============
+
+
+Use ``NotGiven = object()``
+---------------------------
+
+This suffers from all of the drawbacks mentioned in the `Rationale`_ section.
+
+
+Add a single new sentinel value, e.g. ``MISSING`` or ``Sentinel``
+-----------------------------------------------------------------
+
+Since such a value could be used for various things in various places, one
+could not always be confident that it would never be a valid value in some use
+cases.  On the other hand, a dedicated and distinct sentinel value can be used
+with confidence without needing to consider potential edge-cases.
+
+Additionally, it is useful to be able to provide a meaningful name and repr
+for a sentinel value, specific to the context where it is used.
+
+Finally, this was a very unpopular option in the poll, with only 12% of
+the votes voting for it.
+
+
+Use the existing ``Ellipsis`` sentinel value
+--------------------------------------------
+
+This is not the original intended use of Ellipsis, though it has become
+increasingly common to use it to define empty class or function blocks instead
+of using ``pass``.
+
+Also, similar to a potential new single sentinel value, ``Ellipsis`` can't be
+as confidently used in all cases, unlike a dedicated, distinct value.
+
+
+Use a single-valued enum
+------------------------
+
+The suggested idiom is:
+
+::
+
+    class NotGivenType(Enum):
+        NotGiven = 'NotGiven'
+    NotGiven = NotGivenType.NotGiven
+
+Besides the excessive repetition, the repr is overly long:
+``<NotGivenType.NotGiven: 'NotGiven'>``.  A shorter repr can be defined, at
+the expense of a bit more code and yet more repetition.
+
+Finally, this option was the least popular among the nine options in the poll
+[#poll]_, being the only option to receive no votes.
+
+
+A sentinel class decorator
+--------------------------
+
+The suggested interface:
+
+::
+
+    @sentinel(repr='<NotGiven>')
+    class NotGivenType: pass
+    NotGiven = NotGivenType()
+
+While this allowed for a very simple and clear implementation, the interface
+is too verbose, repetitive, and difficult to remember.
+
+
+Using class objects
+-------------------
+
+Since classes are inherently singletons, using a class as a sentinel value
+makes sense and allows for a simple implementation.
+
+The simplest version of this idiom is:
+
+::
+
+   class NotGiven: pass
+
+To have a clear repr, one could define ``__repr__``:
+
+::
+
+    class NotGiven:
+        def __repr__(self):
+            return '<NotGiven>'
+
+... or use a meta-class:
+
+::
+
+    class NotGiven(metaclass=SentinelMeta): pass
+
+However, all such implementations don't have a dedicated type for the
+sentinel, which is considered desirable.  A dedicated type could be created
+by a meta-class or class decorator, but at that point the implementation would
+become much more complex and loses its advantages over the chosen
+implementation.
+
+Additionally, using classes this way is unusual and could be confusing.
+
+
+Define a recommended "standard" idiom, without supplying an implementation
+--------------------------------------------------------------------------
+
+Most common exiting idioms have significant drawbacks.  So far, no idiom
+has been found that is clear and concise while avoiding these drawbacks.
+
+Also, in the poll on this subject [#poll]_, the options for recommending an
+idiom were unpopular, with the highest-voted option being voted for by only
+25% of the voters.
+
+
+Additional Notes
+================
+
+* This PEP and the initial implementation are drafted in a dedicated GitHub
+  repo [#reference-github-repo]_.
+
+* The support for copying/unpickling works when defined in a module's scope or
+  a (possibly nested) class's scope.  Note that in the latter case, the name
+  provided as the first parameter must be the fully-qualified name of the
+  variable in the module::
+
+      class MyClass:
+          NotGiven = sentinel('MyClass.NotGiven', repr='<NotGiven>')
+
+
+References
+==========
+
+.. [#reference-github-repo] `Reference implementation at the taleinat/python-stdlib-sentinels GitHub repo <https://github.com/taleinat/python-stdlib-sentinels>`_
+.. [#python-dev-thread] Python-Dev mailing list: `The repr of a sentinel <https://mail.python.org/archives/list/python-dev@python.org/thread/ZLVPD2OISI7M4POMTR2FCQTE6TPMPTO3/>`_
+.. [#list-of-sentinels-in-stdlib] Python-Dev mailing list: `"The stdlib contains tons of sentinels" <https://mail.python.org/archives/list/python-dev@python.org/message/JBYXQH3NV3YBF7P2HLHB5CD6V3GVTY55/>`_
+.. [#poll] discuss.python.org Poll: `Sentinel Values in the Stdlib <https://discuss.python.org/t/sentinel-values-in-the-stdlib/8810/>`_
+.. [5] `bpo-44123: Make function parameter sentinel values true singletons <https://bugs.python.org/issue44123>`_
+.. [6] `The "sentinels" package on PyPI <https://pypi.org/project/sentinels/>`_
+.. [7] `The "sentinel" package on PyPI <https://pypi.org/project/sentinel/>`_
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
+
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-0661.rst
+++ b/pep-0661.rst
@@ -148,7 +148,7 @@ The reference implementation is found in a dedicated GitHub repo
         globals()[class_name] = cls
 
         sentinel = cls()
-        cls.__new__ lambda cls: sentinel
+        cls.__new__ = lambda cls: sentinel
 
         return sentinel
 

--- a/pep-0661.rst
+++ b/pep-0661.rst
@@ -1,6 +1,7 @@
 PEP: 661
 Title: Sentinel Values
 Author: Tal Einat <tal@python.org>
+Discussions-To: https://discuss.python.org/t/pep-661-sentinel-values/9126
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst

--- a/pep-0661.rst
+++ b/pep-0661.rst
@@ -36,17 +36,12 @@ Motivation
 In May 2021, a question was brought up on the python-dev mailing list
 [#python-dev-thread]_ about how to better implement a sentinel value for
 ``traceback.print_exception``.  The existing implementation used the
-following common idiom:
-
-::
+following common idiom::
 
     _sentinel = object()
 
-However, this object has an overly verbose repr, causing the function's
-signature to be overly long and hard to read, as seen e.g. when calling
-``help()``:
-
-::
+However, this object has an uninformative and overly verbose repr, causing the
+function's signature to be overly long and hard to read::
 
     >>> help(traceback.print_exception)
     Help on function print_exception in module traceback:
@@ -73,7 +68,7 @@ The discussion did not lead to any clear consensus on whether a standard
 implementation method is needed or desirable, whether the drawbacks mentioned
 are significant, nor which kind of implementation would be good.
 
-A poll was created on discuss.python.org [#poll]_to get a clearer sense of
+A poll was created on discuss.python.org [#poll]_ to get a clearer sense of
 the community's opinions. The poll's results were not conclusive, with 40%
 voting for "The status-quo is fine / there’s no need for consistency in
 this", but most voters voting for one or more standardized solutions.
@@ -184,8 +179,8 @@ with confidence without needing to consider potential edge-cases.
 Additionally, it is useful to be able to provide a meaningful name and repr
 for a sentinel value, specific to the context where it is used.
 
-Finally, this was a very unpopular option in the poll, with only 12% of
-the votes voting for it.
+Finally, this was a very unpopular option in the poll [#poll]_, with only 12%
+of the votes voting for it.
 
 
 Use the existing ``Ellipsis`` sentinel value
@@ -297,10 +292,10 @@ Additional Notes
 References
 ==========
 
-.. [#reference-github-repo] `Reference implementation at the taleinat/python-stdlib-sentinels GitHub repo <https://github.com/taleinat/python-stdlib-sentinels>`_
 .. [#python-dev-thread] Python-Dev mailing list: `The repr of a sentinel <https://mail.python.org/archives/list/python-dev@python.org/thread/ZLVPD2OISI7M4POMTR2FCQTE6TPMPTO3/>`_
 .. [#list-of-sentinels-in-stdlib] Python-Dev mailing list: `"The stdlib contains tons of sentinels" <https://mail.python.org/archives/list/python-dev@python.org/message/JBYXQH3NV3YBF7P2HLHB5CD6V3GVTY55/>`_
 .. [#poll] discuss.python.org Poll: `Sentinel Values in the Stdlib <https://discuss.python.org/t/sentinel-values-in-the-stdlib/8810/>`_
+.. [#reference-github-repo] `Reference implementation at the taleinat/python-stdlib-sentinels GitHub repo <https://github.com/taleinat/python-stdlib-sentinels>`_
 .. [5] `bpo-44123: Make function parameter sentinel values true singletons <https://bugs.python.org/issue44123>`_
 .. [6] `The "sentinels" package on PyPI <https://pypi.org/project/sentinels/>`_
 .. [7] `The "sentinel" package on PyPI <https://pypi.org/project/sentinel/>`_

--- a/pep-0662.rst
+++ b/pep-0662.rst
@@ -1,7 +1,7 @@
-PEP: 9999
-Title: Editable installs
+PEP: 662
+Title: Editable installs via virtual wheels
 Author: Bernát Gábor <gaborjbernat@gmail.com>
-Sponsor: TBD
+Sponsor: Brett Cannon <brett@python.org>
 Discussions-To: https://discuss.python.org/t/discuss-tbd-editable-installs-by-gaborbernat/9071
 Status: Draft
 Type: Standards Track
@@ -14,42 +14,53 @@ Abstract
 
 This document describes extensions to the build backend and frontend
 communication (as introduced by :pep:`517`) to allow projects to be installed in
-editable mode.
+editable mode by introducing virtual wheels.
 
 Motivation
 ==========
 
 During development, many Python users prefer to install their libraries so that
-changes to the underlying source code are automatically reflected in subsequent
-interpreter invocations without an additional installation step. This mode is
-usually called "development mode" or "editable installs". Currently, there is no
-standardized way to accomplish this, as it was explicitly left out of :pep:`517`
-due to the complexity of the actual observed behaviors.
+changes to the underlying source code and resources are automatically reflected
+in subsequent interpreter invocations without an additional installation step.
+This mode is usually called "development mode" or "editable installs".
+Currently, there is no standardized way to accomplish this, as it was explicitly
+left out of :pep:`517` due to the complexity of the actual observed behaviors.
 
-At the moment, users can achieve this in a few ways:
+At the moment, users can achieve this in a few ways, neither of them being a
+standard:
 
--  Adding the relevant source directories to ``sys.path`` (configurable from the
-   command line interface via the ``PYTHONPATH`` environment variable). Note in
-   this case, the users have to install the project dependencies themselves, and
-   entry points or project metadata are not generated.
+-  For just Python code by adding the relevant source directories to
+   ``sys.path`` (configurable from the command line interface via the
+   ``PYTHONPATH`` environment variable). Note in this case, the users have to
+   install the project dependencies themselves, and entry points or project
+   metadata are not generated.
 
--  setuptools_ provides the `setup.py develop`_ mechanism: installs a ``pth``
-   file that injects the project root onto the ``sys.path`` at interpreter
-   startup time, generates the project metadata, and also installs project
-   dependencies. pip_ exposes calling this mechanism via the `pip install -e
-   <project_directory>`_ command-line interface.
+-  setuptools_ provides the `setup.py develop`_ mechanism: that installs a
+   ``pth`` file that injects the project root onto the ``sys.path`` at
+   interpreter startup time, generates the project metadata, and also installs
+   project dependencies. pip_ exposes calling this mechanism via the
+   `pip install -e <project_directory>`_ command-line interface.
 
 -  flit_ provides the `flit install --symlink`_ command that symlinks the
-   project files into the interpreters ``purelib`` folder, generates the project
-   metadata, and also installs dependencies.
+   project files into the interpreters ``purelib`` folder, generates the
+   project metadata, and also installs dependencies. Note, this allows
+   supporting resource files too.
 
-This PEP aims to delineate the frontend and the backend roles clearly and give
-the developers of each the maximum ability to provide valuable features to their
-users. In this proposal, the backend's role is to prepare the project for an
-editable installation and enumerating how the installed layout maps onto the
-layout on disk; the frontend's role is to take this mapping and expose the
-relevant files to the target interpreter. Project metadata follows the same
-responsibility structure as in :pep:`517`.
+As these examples shows an editable install can be achieved in multiple ways
+and at the moment there's no standard way of doing it. Furthermore, it's not
+clear whose responsibility it is to achieve and define what an editable
+installation is:
+
+1. allow the build backend to define and materialize it,
+2. allow the build frontend to define and materialize it,
+3. explicitly define and standardize one method from the possible options.
+
+The author of this PEP believes there's no one size fits all solution here,
+each method of achieving editable effect has its pros and cons. Therefore
+this PEP rejects option three as it's unlikely for the community to agree on a
+single solution. Therefore, question remains as to whether the frontend or the
+build backend should own this responsibility. :pep:`660` proposes the build
+backend to own this, while the current PEP proposes the frontend.
 
 Rationale
 =========
@@ -66,14 +77,32 @@ current communication method.
 Terminology and goals
 =====================
 
-The editable installation mode implies that the source code of the project being
-installed is available in a local directory.
+This PEP aims to delineate the frontend and the backend roles clearly and give
+the developers of each the maximum ability to provide valuable features to
+their users. In this proposal, the backend's role is to prepare the project for
+an editable installation, and then provide enough information to the frontend
+so that the frontend can manifest and enforce the editable installation.
 
-Once the project is installed in editable mode, some changes to the project code
-in the local source tree will become effective without the need for a new
-installation step. At a minimum, changes to the text of non-generated files that
-existed at the installation time should be reflected upon the subsequent import
-of the package.
+The information the backend provides to the frontend is:
+
+- the project metadata (as defined by :pep:`427` under ``.dist-info``),
+- the files to expose (formulated as a mapping of absolute source tree
+  paths to relative target interpreter destination paths).
+
+We refer to this set of information as the virtual wheel. This virtual wheel
+should contain all information a wheel contains, however it's not zipped and
+its installation will not be done by copying the files. The frontend's role is
+to take the virtual wheel and install the project in editable mode. The way it
+achieves this is entirely up to the frontend and is considered implementation
+detail.
+
+The editable installation mode implies that the source code of the project
+being installed is available in a local directory. Once the project is
+installed in editable mode, some changes to the project code in the local
+source tree will become effective without the need for a new installation step.
+At a minimum, changes to the text of non-generated files that existed at the
+installation time should be reflected upon the subsequent import of the
+package.
 
 Some kinds of changes, such as adding or modifying entry points or new
 dependencies, require a new installation step to become effective. These changes
@@ -108,7 +137,6 @@ For reference, a non-editable installation works as follows:
 
 The Mechanism
 =============
-
 
 This PEP adds two optional hooks to the :pep:`517` backend interface. One of the
 hooks is used to specify the build dependencies of an editable install. The
@@ -219,6 +247,16 @@ The frontend must not rely on the ``prepare_metadata_for_build_wheel`` hook when
 installing in editable mode. It must instead invoke ``build_editable`` and use
 the ``.dist-info`` folder returned by that.
 
+If the frontend concludes it cannot achieve an editable installation with the
+information provided by the build backend it should fail and raise an error to
+clarify to the user why not.
+
+The frontend might implement one or more editable installation mechanisms and
+can leave it up to the user the choose one that its optimal to the use case
+of the user. For example, pip could add an editable mode flag, and allow the
+user to choose between ``pth`` files or symlinks (
+``pip install -e . --editable=pth`` vs ``pip install -e . --editable=symlink``).
+
 Example editable implementations
 --------------------------------
 
@@ -229,7 +267,7 @@ Add the source tree as is to the interpreter
 ''''''''''''''''''''''''''''''''''''''''''''
 
 This is one of the simplest implementations, it will add the source tree as is
-into the interpreters schema paths.
+into the interpreters schema paths, the virtual wheel might look like:
 
 .. code::
 
@@ -296,12 +334,21 @@ where this is useful:
 Rejected ideas
 ==============
 
-This PEP competes with :pep:`660` and rejects that proposal because we think the
-mechanism of achieving an editable installation should be within the build
+This PEP competes with :pep:`660` and rejects that proposal because we think
+the mechanism of achieving an editable installation should be within the
 frontend rather than the build backend. Furthermore, this approach allows the
 ecosystem to use alternative means to accomplish the editable installation
 effect (e.g., insert path on ``sys.path`` or symlinks instead of just implying
 the loose wheel mode from the backend described by that PEP).
+
+Prominently, :pep:`660` does not allow using symlinks to expose code and data
+files without also extending the wheel file standard with symlink support. It's
+not clear how the wheel format could be extended to support symlinks that refer
+not to files within the wheel itself, but files only available on the local
+disk. It's important to note that the backend itself (or backend generated
+code) must not generate these symlinks (e.g., at interpreter startup time) as
+that would conflict with the frontends book keeping of what files need to be
+uninstalled.
 
 References
 ==========

--- a/pep-8001.rst
+++ b/pep-8001.rst
@@ -10,7 +10,7 @@ Author: Brett Cannon <brett@python.org>,
         Nathaniel J. Smith <njs@pobox.com>,
         Pablo Galindo Salgado <pablogsal@python.org>,
         Raymond Hettinger <python@rcn.com>,
-        Tal Einat <taleinat@gmail.com>,
+        Tal Einat <tal@python.org>,
         Tim Peters <tim.peters@gmail.com>,
         Zachary Ware <zachary.ware@gmail.com>
 Status: Accepted

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,0 +1,205 @@
+PEP: 9999
+Title: Editable installs
+Author: Bernát Gábor <gaborjbernat@gmail.com>
+Sponsor: TBD
+Discussions-To: https://discuss.python.org/t/draft-pep-editable-installs-for-pep-517-style-build-backends/8510
+Status: Draft
+Type: Standards Track
+Content-Type: text/x-rst
+Created: 28-May-2021
+Post-History: 
+
+
+Abstract
+========
+
+This document describes extensions to the build backend and frontend communication (as introduced by `PEP-517`_) to allow projects to be installed in editable mode.
+
+Motivation
+==========
+
+During development, many Python users prefer to install their libraries so that changes to the underlying source code are automatically reflected in subsequent interpreter invocations without an additional installation step. This mode is usually called "development mode" or "editable installs". Currently, there is no standardized way to accomplish this, as it was explicitly left out of `PEP-517`_ due to the complexity of the actual observed behaviors.
+
+At the moment, users can achieve this in a few ways:
+
+- Adding the relevant source directories to ``sys.path`` (configurable from the command line interface via the ``PYTHONPATH`` environment variable). Note in this case, the users have to install the project dependencies themselves, and entry points or project metadata are not generated.
+- `setuptools`_ provides the `setup.py develop`_ mechanism: installs a ``pth`` file that injects the project root onto the ``sys.path`` at interpreter startup time, generates the project metadata, and also installs project dependencies. `pip`_ exposes calling this mechanism via the `pip install -e <project_directory>`_ command-line interface.
+- `flit`_ provides the `flit install --symlink`_ command that symlinks the project files into the interpreters ``purelib`` folder, generates the project metadata, and also installs dependencies.
+
+This PEP aims to delineate the frontend and the backend roles clearly and give the developers of each the maximum ability to provide valuable features to their users. In this proposal, the backend's role is to prepare the project for an editable installation and enumerating how the installed layout maps onto the layout on disk; the frontend's role is to take this mapping and expose the relevant files to the target interpreter. Project metadata follows the same responsibility structure as in `PEP-517`_.
+
+Rationale
+=========
+
+`PEP-517`_ deferred "Editable installs" because this would have delayed further its adoption, and there wasn't an agreement on how editable installs should be achieved. Due to the popularity of the `setuptools`_ and `pip`_ projects, the status quo prevailed, and the backend could achieve editable mode by providing
+a ``setup.py develop`` implementation, which the user could trigger via `pip install -e <project_directory>`_. By defining an editable interface
+between the build backend and frontend, we can eliminate the ``setup.py`` file and their current communication method.
+
+Terminology and goals
+=====================
+
+The editable installation mode implies that the source code of the project being installed is available in a local directory.
+
+Once the project is installed in editable mode, some changes to the project code in the local source tree will become effective without the need for a new installation step. At a minimum, changes to the text of non-generated files that existed at the installation time should be reflected upon the subsequent import of the package.
+
+Some kinds of changes, such as adding or modifying entry points or new dependencies, require a new installation step to become effective. These changes are typically made in build backend configuration files (such as ``pyproject.toml``). This requirement is consistent with the general user expectation that such modifications will only become effective after re-installation.
+
+While users expect editable installations to behave identically to standard installations, this may not always be possible and may be in tension with other user expectations. Depending on how a frontend implements the editable mode, some differences may be visible, such as the presence of additional files (compared to a typical installation), either in the source tree or the interpreter's installation path. Frontends should seek to minimize differences between the behavior of editable and standard installations and document known differences.
+
+For reference, a non-editable installation works as follows:
+
+1. The **developer** is using a tool, we'll call it here the **frontend**, to drive the project development (e.g., `pip`_). When the user wants to trigger a package build and installation of a project, they'll communicate with the **frontend**.
+2. The frontend uses a **build frontend** to trigger the build of a wheel (e.g., `build`_). The build frontend uses `PEP-517`_ to communicate with the **build backend** (e.g. `setuptools`_) - with the build backend installed into a `PEP-518`_ environment. Once invoked, the backend returns a wheel.
+3. The frontend takes the wheel and feeds it to an **installer** (e.g.,`installer`_) to install the wheel into the target Python interpreter.
+
+The Mechanism
+=============
+
+This PEP adds two optional hooks to the `PEP-517`_ backend interface. One of the hooks is used to specify the build dependencies of an editable install. The other hook returns the necessary information via the build frontend the frontend needs to create an editable install.
+
+get_requires_for_build_editable
+-------------------------------
+
+::
+
+  def get_requires_for_build_editable(config_settings=None):
+      ...
+
+This hook MUST return an additional sequence of strings containing `PEP-508`_ dependency specifications, above and beyond those specified in the ``pyproject.toml`` file. The frontend must ensure that these dependencies are available in the build environment in which the ``build_editable`` hook is called.
+
+If not defined, the default implementation is equivalent to returning ``[]``.
+
+build_editable
+--------------
+
+::
+
+  def build_editable(config_settings=None):
+      ...
+
+The function returns an object of type ``EditableInfo`` as defined below:
+
+::
+
+  from typing import Mapping, Sequence, TypedDict
+
+
+  class RequiredEditableInfo(TypedDict, total=True):
+      version: int
+      """protocol version of the editable metadata, this PEP defines version 1"""
+
+      metadata_for_build_editable: str
+      """distribution information of the package as defined by PEP-491"""
+
+  class EditableInfo(RequiredEditableInfo, total=False):
+
+      purelib_paths: Mapping[str, str]
+      """files or folders that should be available under the purelib"""
+
+      platlib_paths: Mapping[str, str]
+      """files or folders that should be available under the platlib"""
+
+
+
+The ``purelib`` and ``platlib`` paths map from project source absolute paths to target directory relative paths. We allow backends to change the project layout from the project source directory to what the interpreter will see by using the mapping.
+
+Build frontend requirements
+---------------------------
+
+The build frontend is responsible for setting up the environment for the build backend to generate the necessary information for an editable build. It's also responsible for communicating with the backend and receiving the ``EditableInfo`` object. All recommendations from `PEP-517`_ for the build wheel hook applies here too.
+
+Frontend requirements
+---------------------
+
+The frontend is responsible for ensuring the ``.dist-info`` folder is available at runtime within the target interpreter for the ``importlib.metadata`` and ``importlib.resources`` modules.
+
+The frontend must ensure that all installation requirements specified in the distribution information files are installed as part of the editable installation into the target interpreter. Additionally, the user might also select additional ``extras`` groups that also should be installed as part of the editable installation.
+
+The frontend also must generate entrypoints, which may be for the console or the GUI. Those entrypoints are defined by the distribution information files, which are generated during the editable installation process.
+
+The frontend is responsible for generating the ``RECORD`` file based on the object the build backend returns and their chosen editable implementation. For this reason, the uninstallation of editables should not require any special treatment.
+
+The frontend must create a ``direct_url.json`` file in the ``.dist-info`` directory of the installed distribution, in compliance with PEP 610. The ``url`` value must be a ``file://`` URL pointing to the project directory (i.e., the directory containing ``pyproject.toml``), and the ``dir_info`` value must be ``{'editable': true}``.
+
+The frontend must not rely on the ``prepare_metadata_for_build_wheel`` hook when installing in editable mode. It must instead invoke ``build_editable`` and use the ``.dist-info`` folder returned by that.
+
+Example editable implementations
+--------------------------------
+
+To show how this PEP might be used, we'll now present a few case studies. Note the offered solutions are purely for illustrating purpose.
+
+Add the source tree as is to the interpreter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is one of the simplest implementations, it will add the source tree as is into the interpreters schema paths.
+
+::
+
+    {
+      "metadata_for_build_editable": "<dir to dist-info>",
+      "purelib": {"<project dir>": "<project dir>"}
+    }
+
+The frontend then could either:
+
+- Add the source directory onto the target interpreters ``sys.path`` during startup of it. This is done by creating a ``pth`` file into the target interpreters ``purelib`` folder. `setuptools`_ does this today and is what `pip install -e <project_directory>`_ translate too. This solution is fast and cross-platform compatible. However, this puts the entire source tree onto the system, potentially exposing modules that would not be available in a standard installation case.
+- Symlink the folder, or the individual files within it. This method is what flit does via its `flit install --symlink`_. This solution requires the current platform to support symlinks. Still, it allows potentially to symlink individual files, which could solve the problem of including files that should be excluded from the source tree.
+
+Using custom importers
+~~~~~~~~~~~~~~~~~~~~~~
+
+For a more robust and more dynamic collaboration between the build backend and the target interpreter, we can take advantage of the import system allowing the registration of custom importers. See `PEP-302`_ for more details and `editables`_ as an example of this. The backend can generate a new importer during the editable build (or install it as an additional dependency) and register it at interpreter startup by adding a ``pth`` file.
+
+::
+
+    {
+      "metadata_for_build_editable": "<dir to dist-info>",
+      "purelib": {
+           "<project dir>/.editable/_register_importer.pth": "<project dir>/_register_importer.pth".
+           "<project dir>/.editable/_editable_importer.py": "<project dir>/_editable_importer.py"
+      }
+    }
+
+The backend here registered a hook that is called whenever a new module is imported, allowing dynamic and on-demand functionality. Potential use cases where this is useful:
+
+- Expose a source folder, but honor module excludes: the backend may generate an import hook that consults the exclusion table before allowing a source file loader to discover a file in the source directory or not.
+- For a project, let there be two modules, ``A.py`` and ``B.py``. These are two separate files in the source directory; however, while building a wheel, they are merged into one mega file ``project.py``. In this case, with this PEP, the backend could generate an import hook that reads the source files at import time and merges them in memory before materializing it as a module.
+- Automatically update out-of-date C-extensions: the backend may generate an import hook that checks the last modified timestamp for a C-extension source file. If it is greater than the current C-extension binary, trigger an update by calling the compiler before import.
+
+Rejected ideas
+==============
+
+This PEP competes with ``PEP-660`` and rejects that proposal because we think the mechanism of achieving an editable installation should be within the build frontend rather than the build backend. Furthermore, this approach allows the ecosystem to use alternative means to accomplish the editable installation effect (e.g., insert path on ``sys.path`` or symlinks instead of just implying the loose wheel mode from the backend described by that PEP).
+
+References
+==========
+
+.. _`PEP-302`: https://www.python.org/dev/peps/pep-0517/
+.. _`PEP-517`: https://www.python.org/dev/peps/pep-0517/
+.. _`PEP-508`: https://www.python.org/dev/peps/pep-0508/
+.. _`PEP-518`: https://www.python.org/dev/peps/pep-0518/
+.. _`setuptools`: https://setuptools.readthedocs.io/en/latest/
+.. _`setup.py develop`: https://setuptools.readthedocs.io/en/latest/userguide/commands.html#develop-deploy-the-project-source-in-development-mode
+.. _`pip`: https://pip.pypa.io
+.. _`installer`: https://pypi.org/project/installer
+.. _`build`: https://pypa-build.readthedocs.io
+.. _`pip install -e <project_directory>`: https://pip.pypa.io/en/stable/cli/pip_install/#install-editable
+.. _`flit`: https://flit.readthedocs.io/en/latest/index.html
+.. _`flit install --symlink`: https://flit.readthedocs.io/en/latest/cmdline.html#cmdoption-flit-install-s
+.. _`editables`: https://pypi.org/project/editables
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.
+
+..
+   Local Variables:
+   mode: indented-text
+   indent-tabs-mode: nil
+   sentence-end-double-space: t
+   fill-column: 70
+   coding: utf-8
+   End:

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -2,198 +2,333 @@ PEP: 9999
 Title: Editable installs
 Author: Bernát Gábor <gaborjbernat@gmail.com>
 Sponsor: TBD
-Discussions-To: https://discuss.python.org/t/draft-pep-editable-installs-for-pep-517-style-build-backends/8510
+Discussions-To: https://discuss.python.org/t/discuss-tbd-editable-installs-by-gaborbernat/9071
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
 Created: 28-May-2021
-Post-History: 
-
+Post-History:
 
 Abstract
 ========
 
-This document describes extensions to the build backend and frontend communication (as introduced by `PEP-517`_) to allow projects to be installed in editable mode.
+This document describes extensions to the build backend and frontend
+communication (as introduced by :pep:`517`) to allow projects to be installed in
+editable mode.
 
 Motivation
 ==========
 
-During development, many Python users prefer to install their libraries so that changes to the underlying source code are automatically reflected in subsequent interpreter invocations without an additional installation step. This mode is usually called "development mode" or "editable installs". Currently, there is no standardized way to accomplish this, as it was explicitly left out of `PEP-517`_ due to the complexity of the actual observed behaviors.
+During development, many Python users prefer to install their libraries so that
+changes to the underlying source code are automatically reflected in subsequent
+interpreter invocations without an additional installation step. This mode is
+usually called "development mode" or "editable installs". Currently, there is no
+standardized way to accomplish this, as it was explicitly left out of :pep:`517`
+due to the complexity of the actual observed behaviors.
 
 At the moment, users can achieve this in a few ways:
 
-- Adding the relevant source directories to ``sys.path`` (configurable from the command line interface via the ``PYTHONPATH`` environment variable). Note in this case, the users have to install the project dependencies themselves, and entry points or project metadata are not generated.
-- `setuptools`_ provides the `setup.py develop`_ mechanism: installs a ``pth`` file that injects the project root onto the ``sys.path`` at interpreter startup time, generates the project metadata, and also installs project dependencies. `pip`_ exposes calling this mechanism via the `pip install -e <project_directory>`_ command-line interface.
-- `flit`_ provides the `flit install --symlink`_ command that symlinks the project files into the interpreters ``purelib`` folder, generates the project metadata, and also installs dependencies.
+-  Adding the relevant source directories to ``sys.path`` (configurable from the
+   command line interface via the ``PYTHONPATH`` environment variable). Note in
+   this case, the users have to install the project dependencies themselves, and
+   entry points or project metadata are not generated.
 
-This PEP aims to delineate the frontend and the backend roles clearly and give the developers of each the maximum ability to provide valuable features to their users. In this proposal, the backend's role is to prepare the project for an editable installation and enumerating how the installed layout maps onto the layout on disk; the frontend's role is to take this mapping and expose the relevant files to the target interpreter. Project metadata follows the same responsibility structure as in `PEP-517`_.
+-  setuptools_ provides the `setup.py develop`_ mechanism: installs a ``pth``
+   file that injects the project root onto the ``sys.path`` at interpreter
+   startup time, generates the project metadata, and also installs project
+   dependencies. pip_ exposes calling this mechanism via the `pip install -e
+   <project_directory>`_ command-line interface.
+
+-  flit_ provides the `flit install --symlink`_ command that symlinks the
+   project files into the interpreters ``purelib`` folder, generates the project
+   metadata, and also installs dependencies.
+
+This PEP aims to delineate the frontend and the backend roles clearly and give
+the developers of each the maximum ability to provide valuable features to their
+users. In this proposal, the backend's role is to prepare the project for an
+editable installation and enumerating how the installed layout maps onto the
+layout on disk; the frontend's role is to take this mapping and expose the
+relevant files to the target interpreter. Project metadata follows the same
+responsibility structure as in :pep:`517`.
 
 Rationale
 =========
 
-`PEP-517`_ deferred "Editable installs" because this would have delayed further its adoption, and there wasn't an agreement on how editable installs should be achieved. Due to the popularity of the `setuptools`_ and `pip`_ projects, the status quo prevailed, and the backend could achieve editable mode by providing
-a ``setup.py develop`` implementation, which the user could trigger via `pip install -e <project_directory>`_. By defining an editable interface
-between the build backend and frontend, we can eliminate the ``setup.py`` file and their current communication method.
+:pep:`517` deferred "Editable installs" because this would have delayed further
+its adoption, and there wasn't an agreement on how editable installs should be
+achieved. Due to the popularity of the setuptools_ and pip_ projects, the status
+quo prevailed, and the backend could achieve editable mode by providing a
+``setup.py develop`` implementation, which the user could trigger via `pip
+install -e <project_directory>`_. By defining an editable interface between the
+build backend and frontend, we can eliminate the ``setup.py`` file and their
+current communication method.
 
 Terminology and goals
 =====================
 
-The editable installation mode implies that the source code of the project being installed is available in a local directory.
+The editable installation mode implies that the source code of the project being
+installed is available in a local directory.
 
-Once the project is installed in editable mode, some changes to the project code in the local source tree will become effective without the need for a new installation step. At a minimum, changes to the text of non-generated files that existed at the installation time should be reflected upon the subsequent import of the package.
+Once the project is installed in editable mode, some changes to the project code
+in the local source tree will become effective without the need for a new
+installation step. At a minimum, changes to the text of non-generated files that
+existed at the installation time should be reflected upon the subsequent import
+of the package.
 
-Some kinds of changes, such as adding or modifying entry points or new dependencies, require a new installation step to become effective. These changes are typically made in build backend configuration files (such as ``pyproject.toml``). This requirement is consistent with the general user expectation that such modifications will only become effective after re-installation.
+Some kinds of changes, such as adding or modifying entry points or new
+dependencies, require a new installation step to become effective. These changes
+are typically made in build backend configuration files (such as
+``pyproject.toml``). This requirement is consistent with the general user
+expectation that such modifications will only become effective after
+re-installation.
 
-While users expect editable installations to behave identically to standard installations, this may not always be possible and may be in tension with other user expectations. Depending on how a frontend implements the editable mode, some differences may be visible, such as the presence of additional files (compared to a typical installation), either in the source tree or the interpreter's installation path. Frontends should seek to minimize differences between the behavior of editable and standard installations and document known differences.
+While users expect editable installations to behave identically to standard
+installations, this may not always be possible and may be in tension with other
+user expectations. Depending on how a frontend implements the editable mode,
+some differences may be visible, such as the presence of additional files
+(compared to a typical installation), either in the source tree or the
+interpreter's installation path. Frontends should seek to minimize differences
+between the behavior of editable and standard installations and document known
+differences.
 
 For reference, a non-editable installation works as follows:
 
-1. The **developer** is using a tool, we'll call it here the **frontend**, to drive the project development (e.g., `pip`_). When the user wants to trigger a package build and installation of a project, they'll communicate with the **frontend**.
-2. The frontend uses a **build frontend** to trigger the build of a wheel (e.g., `build`_). The build frontend uses `PEP-517`_ to communicate with the **build backend** (e.g. `setuptools`_) - with the build backend installed into a `PEP-518`_ environment. Once invoked, the backend returns a wheel.
-3. The frontend takes the wheel and feeds it to an **installer** (e.g.,`installer`_) to install the wheel into the target Python interpreter.
+#. The **developer** is using a tool, we'll call it here the **frontend**, to
+   drive the project development (e.g., pip_). When the user wants to trigger a
+   package build and installation of a project, they'll communicate with the
+   **frontend**.
+
+#. The frontend uses a **build frontend** to trigger the build of a wheel (e.g.,
+   build_). The build frontend uses :pep:`517` to communicate with the **build
+   backend** (e.g. setuptools_) - with the build backend installed into a
+   :pep:`518` environment. Once invoked, the backend returns a wheel.
+
+#. The frontend takes the wheel and feeds it to an **installer**
+   (e.g.,`installer`_) to install the wheel into the target Python interpreter.
 
 The Mechanism
 =============
 
-This PEP adds two optional hooks to the `PEP-517`_ backend interface. One of the hooks is used to specify the build dependencies of an editable install. The other hook returns the necessary information via the build frontend the frontend needs to create an editable install.
 
-get_requires_for_build_editable
--------------------------------
+This PEP adds two optional hooks to the :pep:`517` backend interface. One of the
+hooks is used to specify the build dependencies of an editable install. The
+other hook returns the necessary information via the build frontend the frontend
+needs to create an editable install.
 
-::
+``get_requires_for_build_editable``
+-----------------------------------
 
-  def get_requires_for_build_editable(config_settings=None):
-      ...
+.. code::
 
-This hook MUST return an additional sequence of strings containing `PEP-508`_ dependency specifications, above and beyond those specified in the ``pyproject.toml`` file. The frontend must ensure that these dependencies are available in the build environment in which the ``build_editable`` hook is called.
+   def get_requires_for_build_editable(config_settings=None):
+       ...
+
+This hook MUST return an additional sequence of strings containing :pep:`508`
+dependency specifications, above and beyond those specified in the
+``pyproject.toml`` file. The frontend must ensure that these dependencies are
+available in the build environment in which the ``build_editable`` hook is
+called.
 
 If not defined, the default implementation is equivalent to returning ``[]``.
 
-build_editable
---------------
+``build_editable``
+------------------
 
-::
+.. code::
 
-  def build_editable(config_settings=None):
-      ...
+   def build_editable(config_settings=None):
+       ...
 
 The function returns an object of type ``EditableInfo`` as defined below:
 
-::
+.. code::
 
-  from typing import Mapping, Sequence, TypedDict
+   from typing import Mapping, TypedDict
 
+   class SchemaPaths(TypedDict, total=False):
+       """
+       Files and folders that should be mapped:
+       - key is the absolute source path
+       - value is the relative path within the target interpreters prefix
+       """
 
-  class RequiredEditableInfo(TypedDict, total=True):
-      version: int
-      """protocol version of the editable metadata, this PEP defines version 1"""
-
-      metadata_for_build_editable: str
-      """distribution information of the package as defined by PEP-491"""
-
-  class EditableInfo(RequiredEditableInfo, total=False):
-
-      purelib_paths: Mapping[str, str]
-      """files or folders that should be available under the purelib"""
-
-      platlib_paths: Mapping[str, str]
-      """files or folders that should be available under the platlib"""
+       purelib: Mapping[str, str]
+       platlib: Mapping[str, str]
+       headers: Mapping[str, str]
+       scripts: Mapping[str, str]
+       data: Mapping[str, str]
 
 
+   class EditableInfo(TypedDict, total=True):
+       version: int
+       """protocol version of the editable metadata, this PEP defines version 1"""
 
-The ``purelib`` and ``platlib`` paths map from project source absolute paths to target directory relative paths. We allow backends to change the project layout from the project source directory to what the interpreter will see by using the mapping.
+       metadata_for_build_editable: str
+       """distribution information of the package as defined by PEP-491"""
+
+       paths: SchemaPaths
+       """files to expose into the target interpreter"""
+
+
+The schema paths map from project source absolute paths to target directory
+relative paths. We allow backends to change the project layout from the project
+source directory to what the interpreter will see by using the mapping.
+
+For example if the backend returns ``"purelib": {"/me/project/src": ""}`` this
+would mean that expose all files and modules within ``/me/project/src`` at the
+root of the ``purelib`` path within the target interpreter.
 
 Build frontend requirements
 ---------------------------
 
-The build frontend is responsible for setting up the environment for the build backend to generate the necessary information for an editable build. It's also responsible for communicating with the backend and receiving the ``EditableInfo`` object. All recommendations from `PEP-517`_ for the build wheel hook applies here too.
+The build frontend is responsible for setting up the environment for the build
+backend to generate the necessary information for an editable build. It's also
+responsible for communicating with the backend and receiving the
+``EditableInfo`` object. All recommendations from :pep:`517` for the build wheel
+hook applies here too.
 
 Frontend requirements
 ---------------------
 
-The frontend is responsible for ensuring the ``.dist-info`` folder is available at runtime within the target interpreter for the ``importlib.metadata`` and ``importlib.resources`` modules.
+The frontend is responsible for ensuring the ``.dist-info`` folder is available
+at runtime within the target interpreter for the ``importlib.metadata`` and
+``importlib.resources`` modules.
 
-The frontend must ensure that all installation requirements specified in the distribution information files are installed as part of the editable installation into the target interpreter. Additionally, the user might also select additional ``extras`` groups that also should be installed as part of the editable installation.
+The frontend must ensure that all installation requirements specified in the
+distribution information files are installed as part of the editable
+installation into the target interpreter. Additionally, the user might also
+select additional ``extras`` groups that also should be installed as part of the
+editable installation.
 
-The frontend also must generate entrypoints, which may be for the console or the GUI. Those entrypoints are defined by the distribution information files, which are generated during the editable installation process.
+The frontend also must generate entrypoints, which may be for the console or the
+GUI. Those entrypoints are defined by the distribution information files, which
+are generated during the editable installation process.
 
-The frontend is responsible for generating the ``RECORD`` file based on the object the build backend returns and their chosen editable implementation. For this reason, the uninstallation of editables should not require any special treatment.
+The frontend is responsible for generating the ``RECORD`` file based on the
+object the build backend returns and their chosen editable implementation. For
+this reason, the uninstallation of editables should not require any special
+treatment.
 
-The frontend must create a ``direct_url.json`` file in the ``.dist-info`` directory of the installed distribution, in compliance with PEP 610. The ``url`` value must be a ``file://`` URL pointing to the project directory (i.e., the directory containing ``pyproject.toml``), and the ``dir_info`` value must be ``{'editable': true}``.
+The frontend must create a ``direct_url.json`` file in the ``.dist-info``
+directory of the installed distribution, in compliance with PEP 610. The ``url``
+value must be a ``file://`` URL pointing to the project directory (i.e., the
+directory containing ``pyproject.toml``), and the ``dir_info`` value must be
+``{'editable': true}``.
 
-The frontend must not rely on the ``prepare_metadata_for_build_wheel`` hook when installing in editable mode. It must instead invoke ``build_editable`` and use the ``.dist-info`` folder returned by that.
+The frontend must not rely on the ``prepare_metadata_for_build_wheel`` hook when
+installing in editable mode. It must instead invoke ``build_editable`` and use
+the ``.dist-info`` folder returned by that.
 
 Example editable implementations
 --------------------------------
 
-To show how this PEP might be used, we'll now present a few case studies. Note the offered solutions are purely for illustrating purpose.
+To show how this PEP might be used, we'll now present a few case studies. Note
+the offered solutions are purely for illustrating purpose.
 
 Add the source tree as is to the interpreter
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+''''''''''''''''''''''''''''''''''''''''''''
 
-This is one of the simplest implementations, it will add the source tree as is into the interpreters schema paths.
+This is one of the simplest implementations, it will add the source tree as is
+into the interpreters schema paths.
 
-::
+.. code::
 
-    {
-      "metadata_for_build_editable": "<dir to dist-info>",
-      "purelib": {"<project dir>": "<project dir>"}
-    }
+   {
+     "metadata_for_build_editable": "<dir to dist-info>",
+     "purelib": {"<project dir>": "<project dir>"}
+   }
 
 The frontend then could either:
 
-- Add the source directory onto the target interpreters ``sys.path`` during startup of it. This is done by creating a ``pth`` file into the target interpreters ``purelib`` folder. `setuptools`_ does this today and is what `pip install -e <project_directory>`_ translate too. This solution is fast and cross-platform compatible. However, this puts the entire source tree onto the system, potentially exposing modules that would not be available in a standard installation case.
-- Symlink the folder, or the individual files within it. This method is what flit does via its `flit install --symlink`_. This solution requires the current platform to support symlinks. Still, it allows potentially to symlink individual files, which could solve the problem of including files that should be excluded from the source tree.
+-  Add the source directory onto the target interpreters ``sys.path`` during
+   startup of it. This is done by creating a ``pth`` file into the target
+   interpreters ``purelib`` folder. setuptools_ does this today and is what `pip
+   install -e <project_directory>`_ translate too. This solution is fast and
+   cross-platform compatible. However, this puts the entire source tree onto the
+   system, potentially exposing modules that would not be available in a
+   standard installation case.
+
+-  Symlink the folder, or the individual files within it. This method is what
+   flit does via its `flit install --symlink`_. This solution requires the
+   current platform to support symlinks. Still, it allows potentially to symlink
+   individual files, which could solve the problem of including files that
+   should be excluded from the source tree.
 
 Using custom importers
-~~~~~~~~~~~~~~~~~~~~~~
+''''''''''''''''''''''
 
-For a more robust and more dynamic collaboration between the build backend and the target interpreter, we can take advantage of the import system allowing the registration of custom importers. See `PEP-302`_ for more details and `editables`_ as an example of this. The backend can generate a new importer during the editable build (or install it as an additional dependency) and register it at interpreter startup by adding a ``pth`` file.
+For a more robust and more dynamic collaboration between the build backend and
+the target interpreter, we can take advantage of the import system allowing the
+registration of custom importers. See :pep:`302` for more details and editables_
+as an example of this. The backend can generate a new importer during the
+editable build (or install it as an additional dependency) and register it at
+interpreter startup by adding a ``pth`` file.
 
-::
+.. code::
 
-    {
-      "metadata_for_build_editable": "<dir to dist-info>",
-      "purelib": {
-           "<project dir>/.editable/_register_importer.pth": "<project dir>/_register_importer.pth".
-           "<project dir>/.editable/_editable_importer.py": "<project dir>/_editable_importer.py"
-      }
-    }
+   {
+     "metadata_for_build_editable": "<dir to dist-info>",
+     "purelib": {
+          "<project dir>/.editable/_register_importer.pth": "<project dir>/_register_importer.pth".
+          "<project dir>/.editable/_editable_importer.py": "<project dir>/_editable_importer.py"
+     }
+   }
 
-The backend here registered a hook that is called whenever a new module is imported, allowing dynamic and on-demand functionality. Potential use cases where this is useful:
+The backend here registered a hook that is called whenever a new module is
+imported, allowing dynamic and on-demand functionality. Potential use cases
+where this is useful:
 
-- Expose a source folder, but honor module excludes: the backend may generate an import hook that consults the exclusion table before allowing a source file loader to discover a file in the source directory or not.
-- For a project, let there be two modules, ``A.py`` and ``B.py``. These are two separate files in the source directory; however, while building a wheel, they are merged into one mega file ``project.py``. In this case, with this PEP, the backend could generate an import hook that reads the source files at import time and merges them in memory before materializing it as a module.
-- Automatically update out-of-date C-extensions: the backend may generate an import hook that checks the last modified timestamp for a C-extension source file. If it is greater than the current C-extension binary, trigger an update by calling the compiler before import.
+-  Expose a source folder, but honor module excludes: the backend may generate
+   an import hook that consults the exclusion table before allowing a source
+   file loader to discover a file in the source directory or not.
+
+-  For a project, let there be two modules, ``A.py`` and ``B.py``. These are two
+   separate files in the source directory; however, while building a wheel, they
+   are merged into one mega file ``project.py``. In this case, with this PEP,
+   the backend could generate an import hook that reads the source files at
+   import time and merges them in memory before materializing it as a module.
+
+-  Automatically update out-of-date C-extensions: the backend may generate an
+   import hook that checks the last modified timestamp for a C-extension source
+   file. If it is greater than the current C-extension binary, trigger an update
+   by calling the compiler before import.
 
 Rejected ideas
 ==============
 
-This PEP competes with ``PEP-660`` and rejects that proposal because we think the mechanism of achieving an editable installation should be within the build frontend rather than the build backend. Furthermore, this approach allows the ecosystem to use alternative means to accomplish the editable installation effect (e.g., insert path on ``sys.path`` or symlinks instead of just implying the loose wheel mode from the backend described by that PEP).
+This PEP competes with :pep:`660` and rejects that proposal because we think the
+mechanism of achieving an editable installation should be within the build
+frontend rather than the build backend. Furthermore, this approach allows the
+ecosystem to use alternative means to accomplish the editable installation
+effect (e.g., insert path on ``sys.path`` or symlinks instead of just implying
+the loose wheel mode from the backend described by that PEP).
 
 References
 ==========
 
-.. _`PEP-302`: https://www.python.org/dev/peps/pep-0517/
-.. _`PEP-517`: https://www.python.org/dev/peps/pep-0517/
-.. _`PEP-508`: https://www.python.org/dev/peps/pep-0508/
-.. _`PEP-518`: https://www.python.org/dev/peps/pep-0518/
-.. _`setuptools`: https://setuptools.readthedocs.io/en/latest/
-.. _`setup.py develop`: https://setuptools.readthedocs.io/en/latest/userguide/commands.html#develop-deploy-the-project-source-in-development-mode
-.. _`pip`: https://pip.pypa.io
-.. _`installer`: https://pypi.org/project/installer
-.. _`build`: https://pypa-build.readthedocs.io
-.. _`pip install -e <project_directory>`: https://pip.pypa.io/en/stable/cli/pip_install/#install-editable
-.. _`flit`: https://flit.readthedocs.io/en/latest/index.html
-.. _`flit install --symlink`: https://flit.readthedocs.io/en/latest/cmdline.html#cmdoption-flit-install-s
-.. _`editables`: https://pypi.org/project/editables
+.. _build: https://pypa-build.readthedocs.io
 
+.. _editables: https://pypi.org/project/editables
+
+.. _flit: https://flit.readthedocs.io/en/latest/index.html
+
+.. _flit install --symlink: https://flit.readthedocs.io/en/latest/cmdline.html#cmdoption-flit-install-s
+
+.. _installer: https://pypi.org/project/installer
+
+.. _pip: https://pip.pypa.io
+
+.. _pip install -e <project_directory>: https://pip.pypa.io/en/stable/cli/pip_install/#install-editable
+
+.. _setup.py develop: https://setuptools.readthedocs.io/en/latest/userguide/commands.html#develop-deploy-the-project-source-in-development-mode
+
+.. _setuptools: https://setuptools.readthedocs.io/en/latest/
 
 Copyright
 =========
 
-This document is placed in the public domain or under the
-CC0-1.0-Universal license, whichever is more permissive.
+This document is placed in the public domain or under the CC0-1.0-Universal
+license, whichever is more permissive.
 
 ..
    Local Variables:

--- a/pep_sphinx_extensions/__init__.py
+++ b/pep_sphinx_extensions/__init__.py
@@ -1,0 +1,47 @@
+"""Sphinx extensions for performant PEP processing"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sphinx.environment import default_settings
+from docutils.writers.html5_polyglot import HTMLTranslator
+
+from pep_sphinx_extensions.pep_processor.html import pep_html_translator
+from pep_sphinx_extensions.pep_processor.parsing import pep_parser
+from pep_sphinx_extensions.pep_processor.parsing import pep_role
+
+if TYPE_CHECKING:
+    from sphinx.application import Sphinx
+
+# Monkeypatch sphinx.environment.default_settings as Sphinx doesn't allow custom settings or Readers
+# These settings should go in docutils.conf, but are overridden here for now so as not to affect
+# pep2html.py
+default_settings |= {
+    "pep_references": True,
+    "rfc_references": True,
+    "pep_base_url": "",
+    "pep_file_url_template": "pep-%04d.html",
+    "_disable_config": True,  # disable using docutils.conf whilst running both PEP generators
+}
+
+
+def _depart_maths():
+    pass  # No-op callable for the type checker
+
+
+def setup(app: Sphinx) -> dict[str, bool]:
+    """Initialize Sphinx extension."""
+
+    # Register plugin logic
+    app.add_source_parser(pep_parser.PEPParser)  # Add PEP transforms
+    app.add_role("pep", pep_role.PEPRole(), override=True)  # Transform PEP references to links
+    app.set_translator("html", pep_html_translator.PEPTranslator)  # Docutils Node Visitor overrides
+
+    # Mathematics rendering
+    inline_maths = HTMLTranslator.visit_math, _depart_maths
+    block_maths = HTMLTranslator.visit_math_block, _depart_maths
+    app.add_html_math_renderer("maths_to_html", inline_maths, block_maths)  # Render maths to HTML
+
+    # Parallel safety: https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/pep_sphinx_extensions/config.py
+++ b/pep_sphinx_extensions/config.py
@@ -1,0 +1,6 @@
+"""Miscellaneous configuration variables for the PEP Sphinx extensions."""
+
+pep_stem = "pep-{:0>4}"
+pep_url = f"{pep_stem}.html"
+pep_vcs_url = "https://github.com/python/peps/blob/master/"
+pep_commits_url = "https://github.com/python/peps/commits/master/"

--- a/pep_sphinx_extensions/pep_processor/html/pep_html_translator.py
+++ b/pep_sphinx_extensions/pep_processor/html/pep_html_translator.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docutils import nodes
+import sphinx.writers.html5 as html5
+
+if TYPE_CHECKING:
+    from sphinx.builders import html
+
+
+class PEPTranslator(html5.HTML5Translator):
+    """Custom RST -> HTML translation rules for PEPs."""
+
+    def __init__(self, document: nodes.document, builder: html.StandaloneHTMLBuilder):
+        super().__init__(document, builder)
+        self.compact_simple: bool = False
+
+    @staticmethod
+    def should_be_compact_paragraph(node: nodes.paragraph) -> bool:
+        """Check if paragraph should be compact.
+
+        Omitting <p/> tags around paragraph nodes gives visually compact lists.
+
+        """
+        # Never compact paragraphs that are children of document or compound.
+        if isinstance(node.parent, (nodes.document, nodes.compound)):
+            return False
+
+        # Check for custom attributes in paragraph.
+        for key, value in node.non_default_attributes().items():
+            # if key equals "classes", carry on
+            # if value is empty, or contains only "first", only "last", or both
+            # "first" and "last", carry on
+            # else return False
+            if any((key != "classes", not set(value) <= {"first", "last"})):
+                return False
+
+        # Only first paragraph can be compact (ignoring initial label & invisible nodes)
+        first = isinstance(node.parent[0], nodes.label)
+        visible_siblings = [child for child in node.parent.children[first:] if not isinstance(child, nodes.Invisible)]
+        if visible_siblings[0] is not node:
+            return False
+
+        # otherwise, the paragraph should be compact
+        return True
+
+    def visit_paragraph(self, node: nodes.paragraph) -> None:
+        """Remove <p> tags if possible."""
+        if self.should_be_compact_paragraph(node):
+            self.context.append("")
+        else:
+            self.body.append(self.starttag(node, "p", ""))
+            self.context.append("</p>\n")
+
+    def depart_paragraph(self, _: nodes.paragraph) -> None:
+        """Add corresponding end tag from `visit_paragraph`."""
+        self.body.append(self.context.pop())
+
+    def depart_label(self, node) -> None:
+        """PEP link/citation block cleanup with italicised backlinks."""
+        if not self.settings.footnote_backlinks:
+            self.body.append("</span>")
+            self.body.append("</dt>\n<dd>")
+            return
+
+        # If only one reference to this footnote
+        back_references = node.parent["backrefs"]
+        if len(back_references) == 1:
+            self.body.append("</a>")
+
+        # Close the tag
+        self.body.append("</span>")
+
+        # If more than one reference
+        if len(back_references) > 1:
+            back_links = [f"<a href='#{ref}'>{i}</a>" for i, ref in enumerate(back_references, start=1)]
+            back_links_str = ", ".join(back_links)
+            self.body.append(f"<span class='fn-backref''><em> ({back_links_str}) </em></span>")
+
+        # Close the def tags
+        self.body.append("</dt>\n<dd>")
+
+    def unknown_visit(self, node: nodes.Node) -> None:
+        """No processing for unknown node types."""
+        pass

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_parser.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_parser.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sphinx import parsers
+
+from pep_sphinx_extensions.pep_processor.transforms import pep_headers
+from pep_sphinx_extensions.pep_processor.transforms import pep_title
+from pep_sphinx_extensions.pep_processor.transforms import pep_contents
+from pep_sphinx_extensions.pep_processor.transforms import pep_footer
+
+if TYPE_CHECKING:
+    from docutils import transforms
+
+
+class PEPParser(parsers.RSTParser):
+    """RST parser with custom PEP transforms."""
+
+    supported = ("pep", "python-enhancement-proposal")  # for source_suffix in conf.py
+
+    def __init__(self):
+        """Mark the document as containing RFC 2822 headers."""
+        super().__init__(rfc2822=True)
+
+    def get_transforms(self) -> list[type[transforms.Transform]]:
+        """Use our custom PEP transform rules."""
+        return [
+            pep_headers.PEPHeaders,
+            pep_title.PEPTitle,
+            pep_contents.PEPContents,
+            pep_footer.PEPFooter,
+        ]

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_role.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_role.py
@@ -1,0 +1,16 @@
+from sphinx import roles
+
+from pep_sphinx_extensions.config import pep_url
+
+
+class PEPRole(roles.PEP):
+    """Override the :pep: role"""
+
+    def build_uri(self) -> str:
+        """Get PEP URI from role text."""
+        base_url = self.inliner.document.settings.pep_base_url
+        pep_num, _, fragment = self.target.partition("#")
+        pep_base = base_url + pep_url.format(int(pep_num))
+        if fragment:
+            return f"{pep_base}#{fragment}"
+        return pep_base

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_contents.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_contents.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+from docutils import nodes
+from docutils import transforms
+from docutils.transforms import parts
+
+
+class PEPContents(transforms.Transform):
+    """Add TOC placeholder and horizontal rule after PEP title and headers."""
+
+    # Use same priority as docutils.transforms.Contents
+    default_priority = 380
+
+    def apply(self) -> None:
+        if not Path(self.document["source"]).match("pep-*"):
+            return  # not a PEP file, exit early
+
+        # Create the contents placeholder section
+        title = nodes.title("", "Contents")
+        contents_topic = nodes.topic("", title, classes=["contents"])
+        if not self.document.has_name("contents"):
+            contents_topic["names"].append("contents")
+        self.document.note_implicit_target(contents_topic)
+
+        # Add a table of contents builder
+        pending = nodes.pending(Contents)
+        contents_topic += pending
+        self.document.note_pending(pending)
+
+        # Insert the toc after title and PEP headers
+        self.document.children[0].insert(2, contents_topic)
+
+        # Add a horizontal rule before contents
+        transition = nodes.transition()
+        self.document[0].insert(2, transition)
+
+
+class Contents(parts.Contents):
+    """Build Table of Contents from document."""
+    def __init__(self, document, startnode=None):
+        super().__init__(document, startnode)
+
+        # used in parts.Contents.build_contents
+        self.toc_id = None
+        self.backlinks = None
+
+    def apply(self) -> None:
+        # used in parts.Contents.build_contents
+        self.toc_id = self.startnode.parent["ids"][0]
+        self.backlinks = self.document.settings.toc_backlinks
+
+        # let the writer (or output software) build the contents list?
+        if getattr(self.document.settings, "use_latex_toc", False):
+            # move customisation settings to the parent node
+            self.startnode.parent.attributes.update(self.startnode.details)
+            self.startnode.parent.remove(self.startnode)
+        else:
+            contents = self.build_contents(self.document[0])
+            if contents:
+                self.startnode.replace_self(contents)
+            else:
+                # if no contents, remove the empty placeholder
+                self.startnode.parent.parent.remove(self.startnode.parent)

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_footer.py
@@ -1,0 +1,111 @@
+import datetime
+import subprocess
+from pathlib import Path
+
+from docutils import nodes
+from docutils import transforms
+from docutils.transforms import misc
+from docutils.transforms import references
+
+from pep_sphinx_extensions import config
+
+
+class PEPFooter(transforms.Transform):
+    """Footer transforms for PEPs.
+
+     - Appends external links to footnotes.
+     - Creates a link to the (GitHub) source text.
+
+    TargetNotes:
+        Locate the `References` section, insert a placeholder at the end
+        for an external target footnote insertion transform, and schedule
+        the transform to run immediately.
+
+    Source Link:
+        Create the link to the source file from the document source path,
+        and append the text to the end of the document.
+
+    """
+
+    # Uses same priority as docutils.transforms.TargetNotes
+    default_priority = 520
+
+    def apply(self) -> None:
+        pep_source_path = Path(self.document["source"])
+        if not pep_source_path.match("pep-*"):
+            return  # not a PEP file, exit early
+
+        doc = self.document[0]
+        reference_section = copyright_section = None
+
+        # Iterate through sections from the end of the document
+        num_sections = len(doc)
+        for i, section in enumerate(reversed(doc)):
+            if not isinstance(section, nodes.section):
+                continue
+            title_words = section[0].astext().lower().split()
+            if "references" in title_words:
+                reference_section = section
+                break
+            elif "copyright" in title_words:
+                copyright_section = num_sections - i - 1
+
+        # Add a references section if we didn't find one
+        if not reference_section:
+            reference_section = nodes.section()
+            reference_section += nodes.title("", "References")
+            self.document.set_id(reference_section)
+            if copyright_section:
+                # Put the new "References" section before "Copyright":
+                doc.insert(copyright_section, reference_section)
+            else:
+                # Put the new "References" section at end of doc:
+                doc.append(reference_section)
+
+        # Add and schedule execution of the TargetNotes transform
+        pending = nodes.pending(references.TargetNotes)
+        reference_section.append(pending)
+        self.document.note_pending(pending, priority=0)
+
+        # If there are no references after TargetNotes has finished, remove the
+        # references section
+        pending = nodes.pending(misc.CallBack, details={"callback": self.cleanup_callback})
+        reference_section.append(pending)
+        self.document.note_pending(pending, priority=1)
+
+        # Add link to source text and last modified date
+        self.add_source_link(pep_source_path)
+        self.add_commit_history_info(pep_source_path)
+
+    @staticmethod
+    def cleanup_callback(pending: nodes.pending) -> None:
+        """Remove an empty "References" section.
+
+        Called after the `references.TargetNotes` transform is complete.
+
+        """
+        if len(pending.parent) == 2:  # <title> and <pending>
+            pending.parent.parent.remove(pending.parent)
+
+    def add_source_link(self, pep_source_path: Path) -> None:
+        """Add link to source text on VCS (GitHub)"""
+        source_link = config.pep_vcs_url + pep_source_path.name
+        link_node = nodes.reference("", source_link, refuri=source_link)
+        span_node = nodes.inline("", "Source: ", link_node)
+        self.document.append(span_node)
+
+    def add_commit_history_info(self, pep_source_path: Path) -> None:
+        """Use local git history to find last modified date."""
+        args = ["git", "--no-pager", "log", "-1", "--format=%at", pep_source_path.name]
+        try:
+            file_modified = subprocess.check_output(args)
+            since_epoch = file_modified.decode("utf-8").strip()
+            dt = datetime.datetime.utcfromtimestamp(float(since_epoch))
+        except (subprocess.CalledProcessError, ValueError):
+            return None
+
+        commit_link = config.pep_commits_url + pep_source_path.name
+        link_node = nodes.reference("", f"{dt.isoformat()}Z", refuri=commit_link)
+        span_node = nodes.inline("", "Last modified: ", link_node)
+        self.document.append(nodes.line("", "", classes=["zero-height"]))
+        self.document.append(span_node)

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_headers.py
@@ -1,0 +1,119 @@
+import re
+from pathlib import Path
+
+from docutils import nodes
+from docutils import transforms
+from docutils.transforms import peps
+from sphinx import errors
+
+from pep_sphinx_extensions.pep_processor.transforms import pep_zero
+from pep_sphinx_extensions.config import pep_url
+
+
+class PEPParsingError(errors.SphinxError):
+    pass
+
+
+# PEPHeaders is identical to docutils.transforms.peps.Headers excepting bdfl-delegate, sponsor & superseeded-by
+class PEPHeaders(transforms.Transform):
+    """Process fields in a PEP's initial RFC-2822 header."""
+
+    # Run before pep_processor.transforms.pep_title.PEPTitle
+    default_priority = 330
+
+    def apply(self) -> None:
+        if not Path(self.document["source"]).match("pep-*"):
+            return  # not a PEP file, exit early
+
+        if not len(self.document):
+            raise PEPParsingError("Document tree is empty.")
+
+        header = self.document[0]
+        if not isinstance(header, nodes.field_list) or "rfc2822" not in header["classes"]:
+            raise PEPParsingError("Document does not begin with an RFC-2822 header; it is not a PEP.")
+
+        # PEP number should be the first field
+        pep_field = header[0]
+        if pep_field[0].astext().lower() != "pep":
+            raise PEPParsingError("Document does not contain an RFC-2822 'PEP' header!")
+
+        # Extract PEP number
+        value = pep_field[1].astext()
+        try:
+            pep = int(value)
+        except ValueError:
+            raise PEPParsingError(f"'PEP' header must contain an integer. '{value}' is invalid!")
+
+        # Special processing for PEP 0.
+        if pep == 0:
+            pending = nodes.pending(pep_zero.PEPZero)
+            self.document.insert(1, pending)
+            self.document.note_pending(pending)
+
+        # If there are less than two headers in the preamble, or if Title is absent
+        if len(header) < 2 or header[1][0].astext().lower() != "title":
+            raise PEPParsingError("No title!")
+
+        fields_to_remove = []
+        for field in header:
+            name = field[0].astext().lower()
+            body = field[1]
+            if len(body) == 0:
+                # body is empty
+                continue
+            elif len(body) > 1:
+                msg = f"PEP header field body contains multiple elements:\n{field.pformat(level=1)}"
+                raise PEPParsingError(msg)
+            elif not isinstance(body[0], nodes.paragraph):  # len(body) == 1
+                msg = f"PEP header field body may only contain a single paragraph:\n{field.pformat(level=1)}"
+                raise PEPParsingError(msg)
+
+            para = body[0]
+            if name in {"author", "bdfl-delegate", "pep-delegate", "sponsor"}:
+                # mask emails
+                for node in para:
+                    if isinstance(node, nodes.reference):
+                        pep_num = pep if name == "discussions-to" else -1
+                        node.replace_self(peps.mask_email(node, pep_num))
+            elif name in {"replaces", "superseded-by", "requires"}:
+                # replace PEP numbers with normalised list of links to PEPs
+                new_body = []
+                space = nodes.Text(" ")
+                for ref_pep in re.split(r",?\s+", body.astext()):
+                    new_body.append(nodes.reference(
+                        ref_pep, ref_pep,
+                        refuri=(self.document.settings.pep_base_url + pep_url.format(int(ref_pep)))))
+                    new_body.append(space)
+                para[:] = new_body[:-1]  # drop trailing space
+            elif name in {"last-modified", "content-type", "version"}:
+                # Mark unneeded fields
+                fields_to_remove.append(field)
+
+        # Remove unneeded fields
+        for field in fields_to_remove:
+            field.parent.remove(field)
+
+
+def _mask_email(ref: nodes.reference, pep_num: int = -1) -> nodes.reference:
+    """Mask the email address in `ref` and return a replacement node.
+
+    `ref` is returned unchanged if it contains no email address.
+
+    If given an email not explicitly whitelisted, process it such that
+    `user@host` -> `user at host`.
+
+    If given a PEP number `pep_num`, add a default email subject.
+
+    """
+    if "refuri" in ref and ref["refuri"].startswith("mailto:"):
+        non_masked_addresses = {"peps@python.org", "python-list@python.org", "python-dev@python.org"}
+        if ref['refuri'].removeprefix("mailto:").strip() in non_masked_addresses:
+            replacement = ref[0]
+        else:
+            replacement_text = ref.astext().replace("@", "&#32;&#97;t&#32;")
+            replacement = nodes.raw('', replacement_text, format="html")
+
+        if pep_num != -1:
+            replacement['refuri'] += f"?subject=PEP%20{pep_num}"
+        return replacement
+    return ref

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_title.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_title.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from docutils import nodes
+import docutils.transforms as transforms
+
+
+class PEPTitle(transforms.Transform):
+    """Add PEP title and organise document hierarchy."""
+
+    # needs to run before docutils.transforms.frontmatter.DocInfo and after
+    # pep_processor.transforms.pep_title.PEPTitle
+    default_priority = 335
+
+    def apply(self) -> None:
+        if not Path(self.document["source"]).match("pep-*"):
+            return  # not a PEP file, exit early
+
+        # Directory to hold the PEP's RFC2822 header details, to extract a title string
+        pep_header_details = {}
+
+        # Iterate through the header fields, which are the first section of the document
+        for field in self.document[0]:
+            # Hold details of the attribute's tag against its details
+            row_attributes = {sub.tagname: sub.rawsource for sub in field}
+            pep_header_details[row_attributes["field_name"]] = row_attributes["field_body"]
+
+            # We only need the PEP number and title
+            if pep_header_details.keys() >= {"PEP", "Title"}:
+                break
+
+        # Create the title string for the PEP
+        pep_number = int(pep_header_details["PEP"])
+        pep_title = pep_header_details["Title"]
+        pep_title_string = f"PEP {pep_number} -- {pep_title}"  # double hyphen for en dash
+
+        # Generate the title section node and its properties
+        pep_title_node = nodes.section()
+        text_node = nodes.Text(pep_title_string, pep_title_string)
+        title_node = nodes.title(pep_title_string, "", text_node)
+        title_node["classes"].append("page-title")
+        name = " ".join(title_node.astext().lower().split())  # normalise name
+        pep_title_node["names"].append(name)
+        pep_title_node += title_node
+
+        # Insert the title node as the root element, move children down
+        document_children = self.document.children
+        self.document.children = [pep_title_node]
+        pep_title_node.extend(document_children)
+        self.document.note_implicit_target(pep_title_node, pep_title_node)

--- a/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
+++ b/pep_sphinx_extensions/pep_processor/transforms/pep_zero.py
@@ -1,0 +1,74 @@
+from docutils import nodes
+from docutils import transforms
+from docutils.transforms import peps
+
+from pep_sphinx_extensions.config import pep_url
+
+
+class PEPZero(transforms.Transform):
+    """Schedule PEP 0 processing."""
+
+    # Run during sphinx post processing
+    default_priority = 760
+
+    def apply(self) -> None:
+        # Walk document and then remove this node
+        visitor = PEPZeroSpecial(self.document)
+        self.document.walk(visitor)
+        self.startnode.parent.remove(self.startnode)
+
+
+class PEPZeroSpecial(nodes.SparseNodeVisitor):
+    """Perform the special processing needed by PEP 0:
+
+    - Mask email addresses.
+    - Link PEP numbers in the second column of 4-column tables to the PEPs themselves.
+
+    """
+
+    def __init__(self, document: nodes.document):
+        super().__init__(document)
+        self.pep_table: int = 0
+        self.entry: int = 0
+
+    def unknown_visit(self, node: nodes.Node) -> None:
+        """No processing for undefined node types."""
+        pass
+
+    @staticmethod
+    def visit_reference(node: nodes.reference) -> None:
+        """Mask email addresses if present."""
+        node.replace_self(peps.mask_email(node))
+
+    @staticmethod
+    def visit_field_list(node: nodes.field_list) -> None:
+        """Skip PEP headers."""
+        if "rfc2822" in node["classes"]:
+            raise nodes.SkipNode
+
+    def visit_tgroup(self, node: nodes.tgroup) -> None:
+        """Set column counter and PEP table marker."""
+        self.pep_table = node["cols"] == 4
+        self.entry = 0  # reset column number
+
+    def visit_colspec(self, node: nodes.colspec) -> None:
+        self.entry += 1
+        if self.pep_table and self.entry == 2:
+            node["classes"].append("num")
+
+    def visit_row(self, _node: nodes.row) -> None:
+        self.entry = 0  # reset column number
+
+    def visit_entry(self, node: nodes.entry) -> None:
+        self.entry += 1
+        if self.pep_table and self.entry == 2 and len(node) == 1:
+            node["classes"].append("num")
+            # if this is the PEP number column, replace the number with a link to the PEP
+            para = node[0]
+            if isinstance(para, nodes.paragraph) and len(para) == 1:
+                pep_str = para.astext()
+                try:
+                    ref = self.document.settings.pep_base_url + pep_url.format(int(pep_str))
+                    para[0] = nodes.reference(pep_str, pep_str, refuri=ref)
+                except ValueError:
+                    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Requirements for building PEPs with Sphinx
+sphinx >= 3.5
+docutils >= 0.16


### PR DESCRIPTION
Things Paul would like to see changed/amended:

- mapping of paths for purelib/platlib - reorganize source layout into a destination layout
- version number within the returned object
- better name for orchestrator; is it just frontend - but does that differentiates it from the build frontend - do we need to differentiate? 